### PR TITLE
Reverse displayed order of documents

### DIFF
--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -77,7 +77,7 @@ export async function getAllGuFiles(start?: number): Promise<PaginatedResult<Fil
         },
         KeyConditionExpression: "#t = :type AND lastModified > :lastModified",
         ScanIndexForward: false,
-        Limit: 10,
+        Limit: 50,
     })
     const lastEvaluatedKey = results.LastEvaluatedKey
     const token = lastEvaluatedKey !== undefined && typeof lastEvaluatedKey['key'] === "string" ? lastEvaluatedKey['key'] : undefined

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -76,6 +76,7 @@ export async function getAllGuFiles(start?: number): Promise<PaginatedResult<Fil
             "#t": "type"
         },
         KeyConditionExpression: "#t = :type AND lastModified > :lastModified",
+        ScanIndexForward: false,
         Limit: 10,
     })
     const lastEvaluatedKey = results.LastEvaluatedKey


### PR DESCRIPTION
List was displaying oldest first, which is less useful than newest first, and didn't match the old tool.

Also, the old tool displayed 50 results per page rather than 10.