### PR TITLE
Migration preparation

### DIFF
--- a/cdk/lib/__snapshots__/gudocs.test.ts.snap
+++ b/cdk/lib/__snapshots__/gudocs.test.ts.snap
@@ -227,9 +227,11 @@ exports[`The GuDocs stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5032ccf98fdb6dd942f3a2df38053daf327": {
+    "RestApiDeployment180EC5036ed8570902b1d6b70de68097b4681f64": {
       "DependsOn": [
         "RestApiGET0F59260B",
+        "RestApilegacyPOST64491DCB",
+        "RestApilegacy41861923",
         "RestApipublishPOST47D1FC78",
         "RestApipublishEFC5B6CE",
       ],
@@ -247,7 +249,7 @@ exports[`The GuDocs stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5032ccf98fdb6dd942f3a2df38053daf327",
+          "Ref": "RestApiDeployment180EC5036ed8570902b1d6b70de68097b4681f64",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -389,6 +391,139 @@ exports[`The GuDocs stack matches the snapshot 1`] = `
                 "Ref": "RestApi0C43BF4B",
               },
               "/test-invoke-stage/GET/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApilegacy41861923": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "legacy",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApilegacyPOST64491DCB": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "serverlessexpress345C9909",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApilegacy41861923",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApilegacyPOSTApiPermissionGuDocsAPIRestApi65AC27F3POSTlegacy1BF6B12F": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "serverlessexpress345C9909",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/legacy",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApilegacyPOSTApiPermissionTestGuDocsAPIRestApi65AC27F3POSTlegacy704E64A5": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "serverlessexpress345C9909",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/legacy",
             ],
           ],
         },

--- a/cdk/lib/gudocs.ts
+++ b/cdk/lib/gudocs.ts
@@ -121,6 +121,11 @@ export class GuDocs extends GuStack {
 				httpMethod: "POST",
 				lambda: serverlessExpressLambda,
 				},
+				{
+				path: "/legacy",
+				httpMethod: "POST",
+				lambda: serverlessExpressLambda,
+				},
 			],
 		});
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -27,6 +27,7 @@ export const getConfig = async (): Promise<Config> => {
 	const client_email = await configPromiseGetter("client_email")
 	const baseUrl = await configPromiseGetter("base_url")
 	const scheduleEnabled = await configPromiseGetter("schedule_enabled")
+	const legacyKey = await configPromiseGetter("legacy_key")
 
 	return {
 		testFolder,
@@ -37,6 +38,7 @@ export const getConfig = async (): Promise<Config> => {
 		client_email,
 		baseUrl,
 		scheduleEnabled: scheduleEnabled.toLowerCase() === "true",
+		legacyKey,
 	}
 }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -26,6 +26,7 @@ export const getConfig = async (): Promise<Config> => {
 	const require_domain_permissions = await configPromiseGetter("require_domain_permissions")
 	const client_email = await configPromiseGetter("client_email")
 	const baseUrl = await configPromiseGetter("base_url")
+	const scheduleEnabled = await configPromiseGetter("schedule_enabled")
 
 	return {
 		testFolder,
@@ -35,6 +36,7 @@ export const getConfig = async (): Promise<Config> => {
 		s3bucket,
 		client_email,
 		baseUrl,
+		scheduleEnabled: scheduleEnabled.toLowerCase() === "true",
 	}
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,8 @@ import { default as express, type RequestHandler } from "express";
 import { doPublish, doSchedule, getConfig, readDocuments, renderDashboard } from './actions';
 import { getAuthMiddleware } from "./auth-midleware";
 import { IS_RUNNING_LOCALLY } from "./awsIntegration";
+import { saveGuFile } from "./fileManager";
+import type { FileJSON } from "./guFile";
 
 export const createApp = async (): Promise<express.Application> => {
 
@@ -46,6 +48,18 @@ export const createApp = async (): Promise<express.Application> => {
         doPublish(config, fileId).then(() => {
             response.redirect("/")
         }).catch((err) => serverError(err, response))
+    });
+
+    server.post("/legacy", (request: express.Request<unknown, unknown, FileJSON>, response) => {
+        if (request.query['api-key'] === config.legacyKey) {
+            saveGuFile(request.body).then(() => {
+                response.send("ok")
+            }).catch((err) => serverError(err, response))
+        } else {
+          response
+            .status(403)
+            .send("Invalid api-key");
+        }
     });
 
     return server

--- a/src/awsIntegration.ts
+++ b/src/awsIntegration.ts
@@ -23,6 +23,13 @@ const paramStorePromiseGetter =
         Name,
         WithDecryption,
       })
+      .catch((err) => {
+        if (err.__type === 'ParameterNotFound') {
+          return {}
+        } else {
+          throw err
+        }
+      })
       .then((result) => {
         const value = result.Parameter?.Value;
         if (value === undefined) {

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -89,7 +89,7 @@ export async function getAllGuFiles(start?: number): Promise<PaginatedResult<Fil
     }
 }
 
-async function saveGuFile(file: FileJSON): Promise<boolean> {
+export async function saveGuFile(file: FileJSON): Promise<boolean> {
     const lastModified = notEmpty(file.metaData.modifiedDate) ? new Date(file.metaData.modifiedDate).getTime() : new Date().getTime();
 
     const Item = {

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -106,7 +106,7 @@ export async function saveGuFile(file: FileJSON): Promise<boolean> {
         ExpressionAttributeValues: {
             ':limit': lastModified,
         },
-        ConditionExpression: "lastModified <= :limit"
+        ConditionExpression: "attribute_not_exists(lastModified) or lastModified <= :limit"
     });
 
     return true;

--- a/src/guFile.ts
+++ b/src/guFile.ts
@@ -15,6 +15,7 @@ export interface Config {
     s3bucket: string;
     client_email: string;
     baseUrl: string;
+    scheduleEnabled: boolean;
 }
 
 const s3Client = new S3Client(standardAwsConfig);

--- a/src/guFile.ts
+++ b/src/guFile.ts
@@ -16,6 +16,7 @@ export interface Config {
     client_email: string;
     baseUrl: string;
     scheduleEnabled: boolean;
+    legacyKey: string;
 }
 
 const s3Client = new S3Client(standardAwsConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,11 @@ export const scheduleHandler = async (
 	callback: APIGatewayProxyCallback,
 ): Promise<string> => {
 	const config = await getConfig()
-	return await doSchedule(config)
+	if (config.scheduleEnabled) {
+		return await doSchedule(config)
+	} else {
+		return "Schedule disabled"
+	}
 };
 
 if (IS_RUNNING_LOCALLY) {


### PR DESCRIPTION
## What does this change?

This PR adds a few additional features that will be useful when migrating from the old gudocs tool to the this new gudocs2 tool.

- Adds a config option to disable the scheduled task. This will allow us to deploy gudocs2 but leave the legacy gudocs responsible responsible for publishing to begin with
- Adds an endpoint to allow updating Dynamodb without publishing. This will allow us to keep dynamodb in sync with the legacy gudocs redis database (see https://github.com/guardian/gudocs/pull/69)
- Also improves some error handling

## Todo

- Create all CODE parameter store values in PROD, making appropriate modifications including generating a new random key for PROD
- Ensure schedule is disabled
- Deploy to PROD
