### PR TITLE
PROD S3 bucket is in us-east-1

### DIFF
--- a/src/awsIntegration.ts
+++ b/src/awsIntegration.ts
@@ -13,6 +13,14 @@ export const standardAwsConfig = {
     : fromNodeProviderChain(),
 };
 
+export const s3AwsConfig = {
+  region: STAGE === "PROD" ? "us-east-1" : AWS_REGION,
+  credentials: IS_RUNNING_LOCALLY
+    ? fromIni({ profile: LOCAL_PROFILE })
+    : fromNodeProviderChain(),
+};
+
+
 const ssm = new SSM(standardAwsConfig);
 
 const paramStorePromiseGetter =

--- a/src/guFile.ts
+++ b/src/guFile.ts
@@ -3,7 +3,7 @@ import archieml from 'archieml'
 import type { JWT } from 'google-auth-library'
 import type { drive_v2, sheets_v4 } from 'googleapis';
 import Papa from 'papaparse'
-import { standardAwsConfig } from './awsIntegration';
+import { s3AwsConfig, standardAwsConfig } from './awsIntegration';
 import * as drive from './drive'
 import { delay, notEmpty } from './util'
 
@@ -19,7 +19,7 @@ export interface Config {
     legacyKey: string;
 }
 
-const s3Client = new S3Client(standardAwsConfig);
+const s3Client = new S3Client(s3AwsConfig);
 
 interface FileProperties {
     isTable?: boolean;


### PR DESCRIPTION
## What does this change?

We need to use a different AWS configuration for S3 in production because the bucket is in us-east-1. This should hopefully resolve the error:

`The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.`