### PR TITLE
Spreadsheet fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"express": "^4.19.2",
 		"googleapis": "^131.0.0",
 		"javascript-time-ago": "^2.5.10",
-		"papaparse": "^5.4.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1"
 	},

--- a/src/drive.ts
+++ b/src/drive.ts
@@ -1,6 +1,6 @@
 import type { GaxiosPromise } from 'gaxios'
 import type { JWT } from 'google-auth-library'
-import type { drive_v2} from 'googleapis';
+import type { drive_v2, sheets_v4} from 'googleapis';
 import { google } from 'googleapis'
 import { notEmpty, numberOrZero } from './util';
 
@@ -68,10 +68,6 @@ export function getDoc(fileId: string, auth: JWT): GaxiosPromise<string>  {
     }) as GaxiosPromise<string>
 }
 
-export function getSheet(fileId: string, auth: JWT): GaxiosPromise<Blob> {
-    return drive.files.export({
-        auth,
-        fileId: fileId,
-        mimeType: 'text/csv'
-    }) as GaxiosPromise<Blob>
+export async function getSheet(spreadsheetId: string, sheetName: string, auth: JWT): GaxiosPromise<sheets_v4.Schema$ValueRange> {
+    return await sheets.spreadsheets.values.get({ auth, spreadsheetId, range: `${sheetName}!A:ZZ`, valueRenderOption: 'FORMATTED_VALUE' })
 }

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -162,6 +162,7 @@ export async function publishFile(fileId: string, config: Config, auth: JWT): Pr
 
 export async function updateChanged(config: Config, auth: JWT): Promise<unknown> {
     const state = await getStateDb()
+    // todo: add logging
     const changes = await drive.fetchRecentChanges(1 + Number(state.lastChangeId), auth);
     const guFiles = await enrichDriveFilesFromCache(changes.items);
     const updatedJson = await updateFiles(guFiles, false, config, auth);

--- a/src/guFile.ts
+++ b/src/guFile.ts
@@ -126,7 +126,7 @@ async function fetchSheetJSON(sheet: sheets_v4.Schema$Sheet, exportLinks: drive_
     return {[sheet.properties?.title ?? ""]: json};
 }
 
-async function fetchSpreadsheetJSON(file: FileJSON, auth: JWT) {
+async function fetchSpreadsheetJSON(file: FileJSON, auth: JWT): Promise<{'sheets': Record<string, Array<Record<string, string>> | string[][]>}> {
     const spreadsheet = await drive.getSpreadsheet(file.metaData.id, auth);
     let ms = 0;
     const delays = spreadsheet.data.sheets?.map((sheet, n) => {
@@ -140,9 +140,7 @@ async function fetchSpreadsheetJSON(file: FileJSON, auth: JWT) {
         }
 
         return {
-            sheets: {
-                ...sheetJSONs
-            }
+            sheets: sheetJSONs.reduce((a, b) => ({ ...a, ...b, }), {})
         };
     } catch (err) {
         delays.forEach(d => d.cancel());

--- a/src/guFile.ts
+++ b/src/guFile.ts
@@ -116,7 +116,7 @@ async function fetchSheetJSON(sheet: sheets_v4.Schema$Sheet, exportLinks: drive_
     if (sheet.properties?.title !== 'tableDataSheet') {
         const headings = response.data.values?.[0] ?? [];
         return {[sheet.properties?.title ?? ""]: response.data.values?.slice(1).map((row) => {
-            return Object.fromEntries<string>(headings.map((k, i) => [k, row[i]]));
+            return Object.fromEntries<string>(headings.map((k, i) => [k, row[i] ?? ""]));
         }) ?? [] }
     } else {
         return {[sheet.properties.title]: response.data.values as string[][] }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4494,11 +4494,6 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-papaparse@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz"
-  integrity sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"


### PR DESCRIPTION
## What does this change?

This resolves an issue caused by the CSV export doesn't allow you to select different tabs of the spreadsheet.

Instead of using the CSV export function + papaparse we can just use the Google Sheets API. This simplifies the code, removes a library, and most importantly this API does allow you to select different tabs of the spreadsheet.

This PR also reduces the time between making requests in part to deal with the fact that we are now running within the time constrained lambda context. We may need to increase this time again if Google's rate limits still cause issues.