### PR TITLE
Add additional logging

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -14,11 +14,13 @@ interface GoogleAccountDetails {
 }
 
 const getAuth = async () => {
+	console.log("Fetching auth")
 	const googleServiceAccountDetails = JSON.parse(await secretPromiseGetter("serviceAccountKey")) as GoogleAccountDetails;
 	return new google.auth.JWT(googleServiceAccountDetails.client_email, undefined, googleServiceAccountDetails.private_key, ['https://www.googleapis.com/auth/drive']);
 }
 
 export const getConfig = async (): Promise<Config> => {
+	console.log("Fetching config")
 	const testFolder = "docsdata-test"
 	const prodFolder = "docsdata"
 	const s3domain = await configPromiseGetter("s3domain")

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,13 @@ export const scheduleHandler = async (
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- part of lambda API
 	callback: APIGatewayProxyCallback,
 ): Promise<string> => {
+	console.log("Starting scheduled lambda")
 	const config = await getConfig()
 	if (config.scheduleEnabled) {
+		console.log("Running schedule")
 		return await doSchedule(config)
 	} else {
+		console.log("Schedule disabled - skipping")
 		return "Schedule disabled"
 	}
 };


### PR DESCRIPTION
## What does this change?

The scheduled lambda occasionally fails with the error "Error: Client network socket disconnected before secure TLS connection was established". Unfortunately nothing else has been logged before this error, so I don't know how far through the function has got.

Interestingly the error also mentions `s3.eu-west-1.amazonaws.com`. This is surprising, since I think the lambda should have logged something before it writes anything to S3.

In any case, this PR adds some additional logging so that we have more of an idea of when the lambda is failing.