### PR TITLE
upgrade pan-domain-node to 0.5.0 to get updated expiry logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@aws-sdk/credential-providers": "^3.621.0",
 		"@aws-sdk/lib-dynamodb": "^3.621.0",
 		"@codegenie/serverless-express": "^4.14.1",
-		"@guardian/pan-domain-node": "^0.4.2",
+		"@guardian/pan-domain-node": "^0.5.0",
 		"archieml": "^0.5.0",
 		"express": "^4.20.0",
 		"googleapis": "^131.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,12 +1133,12 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.29.1"
 
-"@guardian/pan-domain-node@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/pan-domain-node/-/pan-domain-node-0.4.2.tgz#3f052257f5e0fe346bdcb60196b358b85b928086"
-  integrity sha512-FWFa5JMjkflP0VeDY1Jr3hYnoN+T93CDWoDAlEm+xOc6cc+/lIiDP7iKAshFNRGPYwuoJyTdl7BA+Lrb3UtcAQ==
+"@guardian/pan-domain-node@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/pan-domain-node/-/pan-domain-node-0.5.0.tgz#cd43929b4568359e69540e6ee432e375b0965d18"
+  integrity sha512-mrDxyjFhV21AV5DIK3IUsOGUwHI5pwXho8vaQoY9fiotmp08h+gl0luH8t8J3ldp4YW9k7RbLpAyKebyLcHEbw==
   dependencies:
-    cookie "^0.3.1"
+    cookie "^0.4.1"
     iniparser "^1.0.5"
 
 "@guardian/prettier@^5.0.0":
@@ -2296,10 +2296,10 @@ cookie@0.6.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
-cookie@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cross-spawn@^7.0.2:
   version "7.0.3"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrades pan-domain-node to receive bugfix for cookie expiry date validation

See https://github.com/guardian/pan-domain-authentication/pull/167
