### PR TITLE
Fix forward the permission error of scheduler lambda

### DIFF
--- a/cdk/lib/__snapshots__/gudocs.test.ts.snap
+++ b/cdk/lib/__snapshots__/gudocs.test.ts.snap
@@ -1042,6 +1042,11 @@ exports[`The GuDocs stack matches the snapshot 1`] = `
               },
             },
             {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::pan-domain-auth-settings/*",
+            },
+            {
               "Action": [
                 "dynamodb:BatchGetItem",
                 "dynamodb:GetRecords",

--- a/cdk/lib/gudocs.ts
+++ b/cdk/lib/gudocs.ts
@@ -178,6 +178,9 @@ export class GuDocs extends GuStack {
 		});
 		scheduledLambda.addToRolePolicy(s3BucketPolicy)
 		scheduledLambda.addToRolePolicy(sharedParametersPolicy)
+		// while the scheduled lambda does not need to do authentication, 
+		// it still requires the permission for pan-domain-node package
+		// due to the fact their code are bundle together
 		scheduledLambda.addToRolePolicy(pandaS3BucketPolcy)
 
 		const table = new Table(this, 'Table', {

--- a/cdk/lib/gudocs.ts
+++ b/cdk/lib/gudocs.ts
@@ -178,6 +178,7 @@ export class GuDocs extends GuStack {
 		});
 		scheduledLambda.addToRolePolicy(s3BucketPolicy)
 		scheduledLambda.addToRolePolicy(sharedParametersPolicy)
+		scheduledLambda.addToRolePolicy(pandaS3BucketPolcy)
 
 		const table = new Table(this, 'Table', {
 			tableName: `${this.stack}-${this.stage}-${app}`,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After we bumped the pan-domain-node library to v1.2.0 in #20, we found that the scheduler lambda threw an access denied exception.

In #20, we granted the "Express" lambda with the permission to read objects from the bucket `pan-domain-auth-settings` so that it could load the public settings file with the new version of pan-domain-node.

While the scheduler lambda does not do any authentication, it still set up the `PanDomainAuthentication` class due to the fact that their code are bundled together.

This pull request grant the scheduler lambda with this permission to fix the error.

## How to test

Previously we could see the error log from scheduler:
<img width="1562" height="220" alt="Screenshot 2025-07-28 at 20 08 24" src="https://github.com/user-attachments/assets/cf11c485-87db-4b8a-8589-31f90f0f67f3" />

After deploying the fix, we can see the scheduler can run properly:
<img width="671" height="442" alt="Screenshot 2025-07-29 at 09 16 08" src="https://github.com/user-attachments/assets/749a83aa-992b-4b99-9a13-a7daf8c094fd" />

I also shared a Google sheet with gudoc.  I could see new data coming through after I added new data to the spreadsheet.
<img width="1100" height="202" alt="Screenshot 2025-07-29 at 09 33 35" src="https://github.com/user-attachments/assets/963483a0-837d-4a4d-b368-ccea21ef0c85" />

<img width="388" height="238" alt="Screenshot 2025-07-29 at 09 33 43" src="https://github.com/user-attachments/assets/ccc84cc8-3602-414b-8803-d63b48bdd427" />

