### PR TITLE
Use --frozen-lockfile to ensure lockfile is respected

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ jobs:
           node-version-file: .nvmrc
           cache: 'yarn'
       - run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn build
           yarn package
       - name: CDK synth
         run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn tsc
           yarn lint
           yarn test


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Installs `node_modules` using `yarn install --frozen-lockfile` instead of `yarn-install`, so if there is a discrepancy between the two the installation will fail.

This is motivated by the possibility of supply chain attacks, we do not want to be silently pulling in newer versions of packages.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

I think deploying to CODE and doing a smoke test of sorts would make sense.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Reduced risk of pulling in bad versions of packages.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

If we are somehow relying on the package-lock.json being silently ignored then this could break the build in some subtle way. If so, we can catch this during testing and fix.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
